### PR TITLE
Switch to the general code with the minority_group_proportion

### DIFF
--- a/configs/datamodule/waterbirds_emb_contexts.yaml
+++ b/configs/datamodule/waterbirds_emb_contexts.yaml
@@ -2,7 +2,7 @@ _target_: src.datamodules.WaterbirdsEmbContextsDataModuleV2
 name: waterbirds_emb_contexts
 
 context_class_size: 50
-group_proportions: [0.45, 0.05, 0.05, 0.45] # train set default [0.7295098900794983, 0.03837330639362335, 0.011678831651806831, 0.22043795883655548]
+minority_group_proportion: 0.1 # train set default ~ 0.1
 
 root_dir: ${oc.env:DATA_ROOT_DIR}
 encoding_extractor: dinov2_vitb14

--- a/src/datamodules/waterbirds_emb_contexts_v2.py
+++ b/src/datamodules/waterbirds_emb_contexts_v2.py
@@ -31,7 +31,7 @@ class WaterbirdsEmbContextsDataModuleV2(pl.LightningDataModule):
                  batch_size: int,
                  num_workers: Optional[int],
                  context_class_size: int,
-                 group_proportions: list[float],
+                 minority_group_proportion: float,
                  spurious_setting: str,
                  sp_token_generation_mode: str,
                  v1_behavior: bool,
@@ -49,7 +49,7 @@ class WaterbirdsEmbContextsDataModuleV2(pl.LightningDataModule):
             root_dir=root_dir,
             encoding_extractor=encoding_extractor,
             context_class_size=context_class_size,
-            group_proportions=group_proportions,
+            minority_group_proportion=minority_group_proportion,
             spurious_setting=spurious_setting,
             sp_token_generation_mode=sp_token_generation_mode,
             v1_behavior=v1_behavior,
@@ -72,7 +72,7 @@ class WaterbirdsEmbContextsDataModuleV2(pl.LightningDataModule):
         self._batch_size = batch_size
         self._num_workers = num_workers
         self._context_class_size = context_class_size
-        self._group_proportions = group_proportions
+        self._minority_group_proportion = minority_group_proportion
         self._spurious_setting = spurious_setting
         self._sp_token_generation_mode = sp_token_generation_mode
         self._v1_behavior = v1_behavior


### PR DESCRIPTION
I suggest replacing the code for "waterbirds_emb_contexts" with a more general concept represented by `minority_group_proportion`, This change will simplify our code for calculating the baseline and plotting the graphs of *minority group proportion* versus *Accuracy*.